### PR TITLE
support prod projects; add default values

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -6,6 +6,7 @@ module service-account {
   service_group_name     = "clan1-tribe1-staging"
   clan_gsuite_group      = "tribe-tribe1-clan1"
   domain                 = "extenda.io"
+  env_name               = "staging"
 
   services = [
     {

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -23,6 +23,7 @@ No provider.
 | credentials | JSON encoded service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fallback to GOOGLE\_APPLICATION\_CREDENTIALS env variable. | `any` | n/a | yes |
 | default\_service\_account | Project default service account setting: can be one of delete, deprivilege, disable, or keep. | `string` | `"deprivilege"` | no |
 | domain | Domain name of the Organization | `string` | n/a | yes |
+| env\_name | Environment name (staging/prod). Creation of some resources depends on env_name | `string` | "" | yes |
 | folder\_id | The ID of a folder to host this project | `any` | n/a | yes |
 | name | The name for the project | `any` | n/a | yes |
 | org\_id | The organization ID | `any` | n/a | yes |

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -29,6 +29,7 @@ module "ci_cd_sa" {
   project_id = module.project_factory.project_id
   services   = var.ci_cd_sa
   domain     = var.domain
+  env_name   = var.env_name
 }
 
 module "cloudrun_sa" {
@@ -42,6 +43,7 @@ module "cloudrun_sa" {
   project_id = module.project_factory.project_id
   services   = var.cloudrun_sa
   domain     = var.domain
+  env_name   = var.env_name
 }
 
 module "secret_manager_sa" {
@@ -55,6 +57,7 @@ module "secret_manager_sa" {
   project_id = module.project_factory.project_id
   services   = var.secret_manager_sa
   domain     = var.domain
+  env_name   = var.env_name
 }
 
 module "services_sa" {
@@ -68,4 +71,5 @@ module "services_sa" {
   project_id = module.project_factory.project_id
   services   = var.services
   domain     = var.domain
+  env_name   = var.env_name
 }

--- a/modules/project/vars.tf
+++ b/modules/project/vars.tf
@@ -170,9 +170,16 @@ variable service_group_name {
 variable clan_gsuite_group {
   type        = string
   description = "The name of the clan group that needs to be added to the Service GSuite Group"
+  default     = ""
 }
 
 variable domain {
   type        = string
   description = "Domain name of the Organization"
+}
+
+variable env_name {
+  type        = string
+  description = "Environment name (staging/prod). Creation of some resources depends on env_name"
+  default     = ""
 }

--- a/modules/service-account/README.md
+++ b/modules/service-account/README.md
@@ -17,6 +17,7 @@ For GSuite Group creation you must use a Service Account which is granted GSuite
 | create\_service\_account | If this Service Account should be created | `bool` | n/a | yes |
 | create\_service\_group | If the Service GSuite Group should be created | `bool` | n/a | yes |
 | domain | Domain name of the Organization | `string` | n/a | yes |
+| env\_name | Environment name (staging/prod). Creation of some resources depends on env_name | `string` | n/a | yes |
 | impersonated\_user\_email | Email account of GSuite Admin user to impersonate for creating GSuite Groups. If not provided, will default to `terraform@<var.domain>` | `string` | `""` | no |
 | project\_id | Project ID where we will create the service accounts | `any` | n/a | yes |
 | services | Map of IAM Roles to assign to the Services Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))<br></pre> | n/a | yes |

--- a/modules/service-account/main.tf
+++ b/modules/service-account/main.tf
@@ -77,7 +77,7 @@ resource "gsuite_group_member" "clan_group_member" {
   for_each = {
     for key, value in var.services :
     key => key
-    if var.create_service_account == true && var.create_service_group == true
+    if var.create_service_account == true && var.create_service_group == true && var.env_name == "staging"
   }
   group = "${var.service_group_name}-${var.services[each.value].name}@${var.domain}"
   email = "${var.clan_gsuite_group}@${var.domain}"

--- a/modules/service-account/vars.tf
+++ b/modules/service-account/vars.tf
@@ -40,3 +40,8 @@ variable clan_gsuite_group {
   type        = string
   description = "The name of the clan group that needs to be added to the Service GSuite Group"
 }
+
+variable env_name {
+  type        = string
+  description = "Environment name (staging/prod). Creation of some resources depends on env_name"
+}


### PR DESCRIPTION
- terragrunt project input: 
```
inputs = merge(

  yamldecode(
    file("${get_terragrunt_dir()}/project.yaml")),
  {
    credentials = dependency.departments.outputs.project_provisioner_credentials

    name                = local.name
    bucket_name         = local.bucket_name
    folder_id           = dependency.parent_folder.outputs.folder_id

    service_group_name  = local.service_group_name
    clan_gsuite_group   = local.clan_gsuite_group
    env_name            = local.env_name
  }
)
```

- for the tribe's project creation will be used default values `""`