### PR TITLE
Ability to use shared VPC subnets in a project

### DIFF
--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -31,6 +31,8 @@ No provider.
 | secret\_manager\_sa | Map of IAM Roles to assign to the Secret Manager Access Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))<br></pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/secretmanager.secretAccessor"<br>    ],<br>    "name": "secret-accessor"<br>  }<br>]<br></pre> | no |
 | services | Map of IAM Roles to assign to the Services Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))<br></pre> | n/a | yes |
 | service\_group\_name | Adds a suffix of 4 random characters to the project\_id | `string` | `""` | yes |
+| shared\_vpc | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
+| shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | `[]` | no |
 
 ## Outputs
 

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -16,6 +16,9 @@ module "project_factory" {
   bucket_project  = var.name
 
   activate_apis = var.activate_apis
+
+  shared_vpc         = var.shared_vpc
+  shared_vpc_subnets = var.shared_vpc_subnets
 }
 
 module "ci_cd_sa" {

--- a/modules/project/vars.tf
+++ b/modules/project/vars.tf
@@ -30,6 +30,18 @@ variable activate_apis {
   description = "The list of apis to activate within the project"
 }
 
+variable shared_vpc {
+  type        = string
+  description = "The ID of the host project which hosts the shared VPC"
+  default     = ""
+}
+
+variable shared_vpc_subnets {
+  type        = list(string)
+  description = "List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id)"
+  default     = []
+}
+
 variable default_service_account {
   description = "Project default service account setting: can be one of delete, deprivilege, disable, or keep."
   default     = "deprivilege"


### PR DESCRIPTION
This PR forwards `shared_vpc` and `shared_vpc_subnets` variables to google project-factory module to be able create projects which uses networks from another project's shared VPC.
Also `gsuite_group_email` output added as it needs for dependent resources