### PR TITLE
Create IAM roles in parent (tribe) project for ci/cd SA

### DIFF
--- a/modules/parent-project-iam/main.tf
+++ b/modules/parent-project-iam/main.tf
@@ -1,0 +1,7 @@
+resource "google_project_iam_member" "project_roles" {
+  for_each = var.parent_project_id != "" ? toset(var.parent_project_iam_roles) : toset([])
+
+  project = var.parent_project_id
+  role    = each.key
+  member  = "serviceAccount:${var.service_account}"
+}

--- a/modules/parent-project-iam/vars.tf
+++ b/modules/parent-project-iam/vars.tf
@@ -1,0 +1,14 @@
+variable parent_project_id {
+  type        = string
+  description = "ID of the project to which add additional IAM roles for current project's CI/CD service account. Don't add roles if value is empty"
+}
+
+variable service_account {
+  type        = string
+  description = "Service account email to add IAM roles in parent project for"
+}
+
+variable parent_project_iam_roles {
+  type        = list(string)
+  description = "List of IAM Roles to add to the parent project"
+}

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -33,6 +33,8 @@ No provider.
 | service\_group\_name | Adds a suffix of 4 random characters to the project\_id | `string` | `""` | yes |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | `[]` | no |
+| parent\_project\_id | ID of the project to which add additional IAM roles for current project's CI/CD service account. Ignore if empty | `string` | `""` | no |
+| parent_project_iam_roles | List of IAM Roles to add to the parent project | `list(string)` | `["roles/container.admin","roles/iam.serviceAccountUser"]` | no |
 
 ## Outputs
 

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -1,3 +1,7 @@
+locals {
+  ci_cd_sa_email = var.create_ci_cd_service_account ? module.ci_cd_sa.email[var.ci_cd_sa[0].name] : "mock@nonexisting"
+}
+
 module "project_factory" {
   source  = "terraform-google-modules/project-factory/google"
   version = "6.1"
@@ -75,4 +79,13 @@ module "services_sa" {
   services   = var.services
   domain     = var.domain
   env_name   = var.env_name
+}
+
+module "parent_project_iam" {
+  source = "../parent-project-iam"
+
+  service_account          = local.ci_cd_sa_email
+  parent_project_id        = var.parent_project_id
+  parent_project_iam_roles = var.parent_project_iam_roles
+
 }

--- a/modules/project/vars.tf
+++ b/modules/project/vars.tf
@@ -201,3 +201,18 @@ variable impersonated_user_email {
   description = "Email account of GSuite Admin user to impersonate for creating GSuite Groups. If not provided, will default to `terraform@<var.domain>`"
   default     = ""
 }
+
+variable parent_project_id {
+  type        = string
+  description = "ID of the project to which add additional IAM roles for current project's CI/CD service account. Ignore if empty"
+  default     = ""
+}
+
+variable parent_project_iam_roles {
+  type        = list(string)
+  description = "List of IAM Roles to add to the parent project"
+  default     = [
+    "roles/container.admin",
+    "roles/iam.serviceAccountUser"
+  ]
+}


### PR DESCRIPTION
This PR to create additional roles in parent (tribe) project for current project service account.
It needs to allow access to Kubernetes cluster on Tribe project.