### PR TITLE
feat(ELY-248): Add support for DNS project in CI/CD SA

### DIFF
--- a/modules/external-project-iam-roles/README.md
+++ b/modules/external-project-iam-roles/README.md
@@ -1,0 +1,23 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| gcr\_project\_iam\_roles | List of IAM Roles to add GCR project | `list(string)` | n/a | yes |
+| gcr\_project\_id | ID of the project hosting Google Container Registry | `string` | n/a | yes |
+| gke\_gcr\_iam\_roles | List of IAM Roles to add to the GCR project | `list(string)` | n/a | yes |
+| gke\_parent\_iam\_roles | List of IAM Roles to add to the parent project | `list(string)` | n/a | yes |
+| gke\_service\_account | GKE service account email that IAM roles will be added to | `string` | n/a | yes |
+| parent\_project\_iam\_roles | List of IAM Roles to add to the parent project | `list(string)` | n/a | yes |
+| parent\_project\_id | ID of the project to which add additional IAM roles for current project's CI/CD service account. Don't add roles if value is empty | `string` | n/a | yes |
+| service\_account | Service account email to add IAM roles in parent project for | `string` | n/a | yes |
+
+## Outputs
+
+No output.
+

--- a/modules/external-project-iam-roles/main.tf
+++ b/modules/external-project-iam-roles/main.tf
@@ -31,7 +31,7 @@ resource "google_project_iam_member" "gke_gcr_roles" {
 }
 
 resource "google_project_iam_member" "dns_project_roles" {
-  for_each = var.dns_project_id != "" ? toset(var.dns_project_iam_roles) : toset([])
+  for_each = var.dns_project_id != "" && (var.service_account != "") ? toset(var.dns_project_iam_roles) : toset([])
 
   project = var.dns_project_id
   role    = each.key

--- a/modules/external-project-iam-roles/main.tf
+++ b/modules/external-project-iam-roles/main.tf
@@ -29,3 +29,11 @@ resource "google_project_iam_member" "gke_gcr_roles" {
   role    = each.key
   member  = "serviceAccount:${var.gke_service_account}"
 }
+
+resource "google_project_iam_member" "dns_project_roles" {
+  for_each = var.dns_project_id != "" ? toset(var.dns_project_iam_roles) : toset([])
+
+  project = var.dns_project_id
+  role    = each.key
+  member  = "serviceAccount:${var.service_account}"
+}

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -9,37 +9,41 @@ No provider.
 | activate\_apis | The list of apis to activate within the project | `list(string)` | n/a | yes |
 | billing\_account | The ID of the billing account to associate this project with | `any` | n/a | yes |
 | bucket\_name | The name of the bucket that will contain terraform state - must be globally unique | `any` | n/a | yes |
-| ci\_cd\_sa | Map of IAM Roles to assign to the CI/CD Pipeline Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))<br></pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/iam.serviceAccountUser",<br>      "roles/run.admin",<br>      "roles/storage.admin"<br>    ],<br>    "name": "ci-cd-pipeline"<br>  }<br>]<br></pre> | no |
-| cloudrun\_sa | Map of IAM Roles to assign to the CloudRun Runtime Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))<br></pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/editor",<br>      "roles/secretmanager.secretAccessor"<br>    ],<br>    "name": "cloudrun-runtime"<br>  }<br>]<br></pre> | no |
-| clan\_gsuite\_group | The name of the clan group that needs to be added to the Service GSuite Group | `string` | n/a | yes |
+| ci\_cd\_sa | Map of IAM Roles to assign to the CI/CD Pipeline Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/iam.serviceAccountUser",<br>      "roles/run.admin",<br>      "roles/storage.admin"<br>    ],<br>    "name": "ci-cd-pipeline"<br>  }<br>]</pre> | no |
+| clan\_gsuite\_group | The name of the clan group that needs to be added to the Service GSuite Group | `string` | `""` | no |
+| cloudrun\_sa | Map of IAM Roles to assign to the CloudRun Runtime Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/editor",<br>      "roles/secretmanager.secretAccessor"<br>    ],<br>    "name": "cloudrun-runtime"<br>  }<br>]</pre> | no |
 | create\_ci\_cd\_group | If the Service GSuite Group should be created for the CI/CD Service Account | `bool` | `false` | no |
 | create\_ci\_cd\_service\_account | If the CI/CD Service Account should be created | `bool` | `true` | no |
- create\_cloudrun\_group| If the Service GSuite Group should be created for the CloudRun Runtime Service Account | `bool` | `false` | no |
+| create\_cloudrun\_group | If the Service GSuite Group should be created for the CloudRun Runtime Service Account | `bool` | `false` | no |
 | create\_cloudrun\_service\_account | If the CloudRun Runtime Service Account should be created | `bool` | `true` | no |
 | create\_secret\_manager\_group | If the Service GSuite Group should be created for the Secret Manager Access Service Account | `bool` | `false` | no |
 | create\_secret\_manager\_service\_account | If the Secret Manager Access Service Account should be created | `bool` | `false` | no |
-| create\_service\_group | If the Service GSuite Group should be created for the Services (services variable) | `bool` | `true` | no |
 | create\_service\_sa | If the Service Account for new Services should be created | `bool` | `true` | no |
+| create\_services\_group | If the Service GSuite Group should be created for the Services (services variable) | `bool` | `true` | no |
 | credentials | JSON encoded service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fallback to GOOGLE\_APPLICATION\_CREDENTIALS env variable. | `any` | n/a | yes |
 | default\_service\_account | Project default service account setting: can be one of delete, deprivilege, disable, or keep. | `string` | `"deprivilege"` | no |
+| dns\_project\_iam\_roles | List of IAM Roles to add to DNS project | `list(string)` | <pre>[<br>  "roles/dns.admin"<br>]</pre> | no |
+| dns\_project\_id | ID of the project hosting Google Cloud DNS | `string` | `""` | no |
 | domain | Domain name of the Organization | `string` | n/a | yes |
-| env\_name | Environment name (staging/prod). Creation of some resources depends on env_name | `string` | "" | yes |
+| env\_name | Environment name (staging/prod). Creation of some resources depends on env\_name | `string` | `""` | no |
 | folder\_id | The ID of a folder to host this project | `any` | n/a | yes |
+| gcr\_project\_iam\_roles | List of IAM Roles to add GCR project | `list(string)` | <pre>[<br>  "roles/storage.admin"<br>]</pre> | no |
+| gcr\_project\_id | ID of the project hosting Google Container Registry | `string` | `""` | no |
+| gke\_gcr\_iam\_roles | List of IAM Roles to add to the GCR project for GKE service account | `list(string)` | <pre>[<br>  "roles/storage.objectViewer"<br>]</pre> | no |
+| gke\_parent\_iam\_roles | List of IAM Roles to add to the parent project for GKE service account | `list(string)` | <pre>[<br>  "roles/logging.logWriter",<br>  "roles/monitoring.metricWriter",<br>  "roles/monitoring.viewer"<br>]</pre> | no |
+| gke\_service\_account | GKE service account email that IAM roles will be added to in the parent project | `string` | `""` | no |
+| impersonated\_user\_email | Email account of GSuite Admin user to impersonate for creating GSuite Groups. If not provided, will default to `terraform@<var.domain>` | `string` | `""` | no |
+| labels | Map of labels for the project | `map(string)` | `{}` | no |
 | name | The name for the project | `any` | n/a | yes |
 | org\_id | The organization ID | `any` | n/a | yes |
-| random\_project\_id | Adds a suffix of 4 random characters to the project\_id | `bool` | `true` | no |
-| secret\_manager\_sa | Map of IAM Roles to assign to the Secret Manager Access Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))<br></pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/secretmanager.secretAccessor"<br>    ],<br>    "name": "secret-accessor"<br>  }<br>]<br></pre> | no |
-| services | Map of IAM Roles to assign to the Services Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))<br></pre> | n/a | yes |
-| service\_group\_name | Adds a suffix of 4 random characters to the project\_id | `string` | `""` | yes |
-| shared\_vpc | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
-| shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project_id/regions/$region/subnetworks/$subnet_id) | `[]` | no |
+| parent\_project\_iam\_roles | List of IAM Roles to add to the parent project | `list(string)` | <pre>[<br>  "roles/container.admin",<br>  "roles/iam.serviceAccountUser"<br>]</pre> | no |
 | parent\_project\_id | ID of the project to which add additional IAM roles for current project's CI/CD service account. Ignore if empty | `string` | `""` | no |
-| parent_project_iam_roles | List of IAM Roles to add to the parent project | `list(string)` | `["roles/container.admin","roles/iam.serviceAccountUser"]` | no |
-| gcr\_project\_id | ID of the project hosting Google Container Registry | `string` | `""` | no |
-| gcr\_project\_iam\_roles | List of IAM Roles to add GCR project | `list(string)` | `["roles/storage.admin"]` | no |
-| gke\_service\_account | GKE service account email that IAM roles will be added to | `string` | `""` | no |
-| gke\_parent\_iam\_roles | List of IAM Roles to add to the parent project for GKE service account | `list(string)` | `["roles/logging.logWriter", "roles/monitoring.metricWriter", "roles/monitoring.viewer"]` | no |
-| gke\_gcr\_iam\_roles | List of IAM Roles to add to the GCR project for GKE service account | `list(string)` | `["roles/storage.objectViewer"]` | no |
+| random\_project\_id | Adds a suffix of 4 random characters to the project\_id | `bool` | `true` | no |
+| secret\_manager\_sa | Map of IAM Roles to assign to the Secret Manager Access Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/secretmanager.secretAccessor"<br>    ],<br>    "name": "secret-accessor"<br>  }<br>]</pre> | no |
+| service\_group\_name | The name of the group that will be created for a service | `string` | `""` | no |
+| services | Map of IAM Roles to assign to the Services Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "bar"<br>    ],<br>    "name": "foo"<br>  }<br>]</pre> | no |
+| shared\_vpc | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
+| shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |
 
 ## Outputs
 
@@ -48,9 +52,11 @@ No provider.
 | ci\_cd\_service\_account\_email | The CI/CD pipeline service account email |
 | ci\_cd\_service\_account\_private\_key\_encoded | The CI/CD pipeline service account base64 encoded JSON key |
 | cloudrun\_service\_account\_email | The Cloud Run service account email |
+| gsuite\_group\_email | n/a |
 | project\_id | The project ID |
 | project\_name | The project name |
 | secret\_manager\_service\_account\_private\_key\_encoded | The Cloud Run service account base64 encoded JSON key |
 | service\_account\_email | The default service acccount email |
 | service\_emails | Services service account emails |
 | terraform\_state\_bucket | Bucket for saving terraform state of project resources |
+

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -89,6 +89,8 @@ module "parent_project_iam" {
   parent_project_id        = var.parent_project_id
   parent_project_iam_roles = var.parent_project_iam_roles
 
+  dns_project_id        = var.dns_project_id
+  dns_project_iam_roles = var.dns_project_iam_roles
   gcr_project_id        = var.gcr_project_id
   gcr_project_iam_roles = var.gcr_project_iam_roles
   gke_service_account   = var.gke_service_account

--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -42,7 +42,7 @@ output terraform_state_bucket {
 
 output service_emails {
   description = "Services service account emails"
-  value = module.services_sa.email
+  value       = module.services_sa.email
 }
 
 output gsuite_group_email {

--- a/modules/project/vars.tf
+++ b/modules/project/vars.tf
@@ -217,9 +217,23 @@ variable parent_project_id {
 variable parent_project_iam_roles {
   type        = list(string)
   description = "List of IAM Roles to add to the parent project"
-  default     = [
+  default = [
     "roles/container.admin",
     "roles/iam.serviceAccountUser"
+  ]
+}
+
+variable dns_project_id {
+  type        = string
+  description = "ID of the project hosting Google Cloud DNS"
+  default     = ""
+}
+
+variable dns_project_iam_roles {
+  type        = list(string)
+  description = "List of IAM Roles to add to DNS project"
+  default = [
+    "roles/dns.admin"
   ]
 }
 
@@ -232,7 +246,7 @@ variable gcr_project_id {
 variable gcr_project_iam_roles {
   type        = list(string)
   description = "List of IAM Roles to add GCR project"
-  default     = [
+  default = [
     "roles/storage.admin"
   ]
 }
@@ -246,7 +260,7 @@ variable gke_service_account {
 variable gke_parent_iam_roles {
   type        = list(string)
   description = "List of IAM Roles to add to the parent project for GKE service account"
-  default     = [
+  default = [
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
     "roles/monitoring.viewer"
@@ -256,7 +270,7 @@ variable gke_parent_iam_roles {
 variable gke_gcr_iam_roles {
   type        = list(string)
   description = "List of IAM Roles to add to the GCR project for GKE service account"
-  default     = [
+  default = [
     "roles/storage.objectViewer"
   ]
 }


### PR DESCRIPTION
I have not tested this yet.

Adds inputs `dns_project_id` and `dns_project_iam_roles` to set CI/CD permissions on the DNS project in our organization. The roles list is defaulted to `roles/dns.admin`