### PR TITLE
ELY-258: Fix issue when external IAM roles are tried to create even if local SA absent

### DIFF
--- a/modules/external-project-iam-roles/main.tf
+++ b/modules/external-project-iam-roles/main.tf
@@ -1,5 +1,5 @@
 resource "google_project_iam_member" "parent_project_roles" {
-  for_each = var.parent_project_id != "" ? toset(var.parent_project_iam_roles) : toset([])
+  for_each = (var.parent_project_id != "") && (var.service_account != "") ? toset(var.parent_project_iam_roles) : toset([])
 
   project = var.parent_project_id
   role    = each.key
@@ -7,7 +7,7 @@ resource "google_project_iam_member" "parent_project_roles" {
 }
 
 resource "google_project_iam_member" "gcr_project_roles" {
-  for_each = var.gcr_project_id != "" ? toset(var.gcr_project_iam_roles) : toset([])
+  for_each = (var.gcr_project_id != "") && (var.service_account != "") ? toset(var.gcr_project_iam_roles) : toset([])
 
   project = var.gcr_project_id
   role    = each.key
@@ -15,7 +15,7 @@ resource "google_project_iam_member" "gcr_project_roles" {
 }
 
 resource "google_project_iam_member" "gke_parent_roles" {
-  for_each = var.parent_project_id != "" ? toset(var.gke_parent_iam_roles) : toset([])
+  for_each = (var.parent_project_id != "") && (var.gke_service_account != "") ? toset(var.gke_parent_iam_roles) : toset([])
 
   project = var.parent_project_id
   role    = each.key
@@ -23,7 +23,7 @@ resource "google_project_iam_member" "gke_parent_roles" {
 }
 
 resource "google_project_iam_member" "gke_gcr_roles" {
-  for_each = var.parent_project_id != "" ? toset(var.gke_gcr_iam_roles) : toset([])
+  for_each = (var.parent_project_id != "") && (var.gke_service_account != "") ? toset(var.gke_gcr_iam_roles) : toset([])
 
   project = var.gcr_project_id
   role    = each.key

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -1,5 +1,5 @@
 locals {
-  ci_cd_sa_email = var.create_ci_cd_service_account ? module.ci_cd_sa.email[var.ci_cd_sa[0].name] : "mock@nonexisting"
+  ci_cd_sa_email = var.create_ci_cd_service_account ? module.ci_cd_sa.email[var.ci_cd_sa[0].name] : ""
 }
 
 module "project_factory" {


### PR DESCRIPTION
During creating external resources checks for local SA exist are missing, and IAM roles for non-existing SA are trying to be created.
This PR fix it.