### PR TITLE
feat(ELY-250): Set GitHub secrets on service repos

### DIFF
--- a/modules/github-secret/README.md
+++ b/modules/github-secret/README.md
@@ -2,13 +2,14 @@
 
 | Name | Version |
 |------|---------|
-| external | n/a |
 | github | ~> 2.0 |
+| google-beta | n/a |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| gcp\_secret\_project | GCP project that contains Secret Manager | `string` | `"pipeline-secrets-1136"` | no |
 | github\_organization | GitHub organization | `string` | `"extenda"` | no |
 | repositories | The GitHub repositories to update | `list(string)` | n/a | yes |
 | secret\_name | The GitHub secret name | `string` | n/a | yes |

--- a/modules/github-secret/README.md
+++ b/modules/github-secret/README.md
@@ -1,0 +1,20 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| external | n/a |
+| github | ~> 2.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| github\_organization | GitHub organization | `string` | `"extenda"` | no |
+| repositories | The GitHub repositories to update | `list(string)` | n/a | yes |
+| secret\_name | The GitHub secret name | `string` | n/a | yes |
+| secret\_value | The plaintext secret value to be encrypted with GitHub | `string` | `""` | no |
+
+## Outputs
+
+No output.
+

--- a/modules/github-secret/github_token.sh
+++ b/modules/github-secret/github_token.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# This depends on default credentials being allowed to read secrets.
+# TODO 2 - This token might not have the permissions we need. In that case create one in tf-admin instead.
+SECRET_VALUE=$(berglas access sm://pipeline-secrets-1136/github-token)
+
+# Produce safe JSON
+jq -n --arg token "$SECRET_VALUE" '{"token":$token}'

--- a/modules/github-secret/github_token.sh
+++ b/modules/github-secret/github_token.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# This depends on default credentials being allowed to read secrets.
-# TODO 2 - This token might not have the permissions we need. In that case create one in tf-admin instead.
-SECRET_VALUE=$(berglas access sm://pipeline-secrets-1136/github-token)
-
-# Produce safe JSON
-jq -n --arg token "$SECRET_VALUE" '{"token":$token}'

--- a/modules/github-secret/main.tf
+++ b/modules/github-secret/main.tf
@@ -1,24 +1,15 @@
-# This requires google-beta v3.8 and we're stuck on v2.
-# How can we fetch this token instead? Berglas? Using local-exec
-# data "google_secret_manager_secret_version" "github_token" {
-#   provider = google-beta
-#
-#   project  = "pipeline-secrets-1136"
-#   secret   = "github-token"
-# }
+data "google_secret_manager_secret_version" "github_token" {
+  provider = google-beta
 
-data "external" "github_token" {
-  program = ["bash", "${path.module}/github_token.sh"]
+  project = var.gcp_secret_project
+  secret  = "github-token"
 }
 
 provider "github" {
   version      = "~> 2.0"
-  #token        = data.github_token.secret_data
-  token = data.external.github_token.result["token"]
+  token        = data.google_secret_manager_secret_version.github_token.secret_data
   organization = var.github_organization
 }
-
-// How to for loop a data block?
 
 data "github_actions_public_key" "repo_key" {
   for_each = var.secret_value != "" ? toset(var.repositories) : toset([])

--- a/modules/github-secret/main.tf
+++ b/modules/github-secret/main.tf
@@ -1,0 +1,35 @@
+# This requires google-beta v3.8 and we're stuck on v2.
+# How can we fetch this token instead? Berglas? Using local-exec
+# data "google_secret_manager_secret_version" "github_token" {
+#   provider = google-beta
+#
+#   project  = "pipeline-secrets-1136"
+#   secret   = "github-token"
+# }
+
+data "external" "github_token" {
+  program = ["bash", "${path.module}/github_token.sh"]
+}
+
+provider "github" {
+  version      = "~> 2.0"
+  #token        = data.github_token.secret_data
+  token = data.external.github_token.result["token"]
+  organization = var.github_organization
+}
+
+// How to for loop a data block?
+
+data "github_actions_public_key" "repo_key" {
+  for_each = var.secret_value != "" ? toset(var.repositories) : toset([])
+
+  repository = each.key
+}
+
+resource "github_actions_secret" "gcloud_secret" {
+  for_each = var.secret_value != "" ? toset(var.repositories) : toset([])
+
+  repository      = each.key
+  secret_name     = var.secret_name
+  plaintext_value = var.secret_value
+}

--- a/modules/github-secret/vars.tf
+++ b/modules/github-secret/vars.tf
@@ -1,7 +1,7 @@
 variable gcp_secret_project {
   description = "GCP project that contains Secret Manager"
   type        = string
-  default     = "pipeline-secrets-1136"
+  default     = "tf-admin-90301274"
 }
 
 variable github_organization {

--- a/modules/github-secret/vars.tf
+++ b/modules/github-secret/vars.tf
@@ -1,0 +1,21 @@
+variable github_organization {
+  description = "GitHub organization"
+  type        = string
+  default     = "extenda"
+}
+
+variable repositories {
+  description = "The GitHub repositories to update"
+  type        = list(string)
+}
+
+variable secret_name {
+  description = "The GitHub secret name"
+  type        = string
+}
+
+variable secret_value {
+  description = "The plaintext secret value to be encrypted with GitHub"
+  type        = string
+  default     = ""
+}

--- a/modules/github-secret/vars.tf
+++ b/modules/github-secret/vars.tf
@@ -1,3 +1,9 @@
+variable gcp_secret_project {
+  description = "GCP project that contains Secret Manager"
+  type        = string
+  default     = "pipeline-secrets-1136"
+}
+
 variable github_organization {
   description = "GitHub organization"
   type        = string

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -41,7 +41,7 @@ No provider.
 | random\_project\_id | Adds a suffix of 4 random characters to the project\_id | `bool` | `true` | no |
 | secret\_manager\_sa | Map of IAM Roles to assign to the Secret Manager Access Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/secretmanager.secretAccessor"<br>    ],<br>    "name": "secret-accessor"<br>  }<br>]</pre> | no |
 | service\_group\_name | The name of the group that will be created for a service | `string` | `""` | no |
-| services | Map of IAM Roles to assign to the Services Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "bar"<br>    ],<br>    "name": "foo"<br>  }<br>]</pre> | no |
+| services | Map of IAM Roles to assign to the Services Service Account | <pre>list(object({<br>    name       = string<br>    repository = string<br>    iam_roles  = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "bar"<br>    ],<br>    "name": "foo",<br>    "repository": "foo"<br>  }<br>]</pre> | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |
 

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -5,7 +5,7 @@ locals {
 
 module "project_factory" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "6.1"
+  version = "8.0"
 
   name              = var.name
   random_project_id = var.random_project_id

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -1,5 +1,6 @@
 locals {
   ci_cd_sa_email = var.create_ci_cd_service_account ? module.ci_cd_sa.email[var.ci_cd_sa[0].name] : ""
+  environment    = length(regexall(".*-prod$", var.name)) > 0 ? "prod" : "staging"
 }
 
 module "project_factory" {
@@ -105,4 +106,13 @@ module "workload-identity" {
   cluster_project_id = var.parent_project_id
   services           = var.services
   sa_depends_on      = module.services_sa.email
+}
+
+module "github_secret" {
+  source = "../github-secret"
+
+  repositories = var.services[*].repository
+
+  secret_name  = "GCLOUD_AUTH_${upper(local.environment)}"
+  secret_value = module.ci_cd_sa.private_key_encoded
 }

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -1,6 +1,6 @@
 locals {
   ci_cd_sa_email = var.create_ci_cd_service_account ? module.ci_cd_sa.email[var.ci_cd_sa[0].name] : ""
-  environment    = length(regexall(".*-prod$", var.name)) > 0 ? "prod" : "staging"
+  secret_suffix  = var.env_name == "" ? "" : "_${upper(var.env_name)}"
 }
 
 module "project_factory" {
@@ -113,6 +113,6 @@ module "github_secret" {
 
   repositories = var.services[*].repository
 
-  secret_name  = "GCLOUD_AUTH_${upper(local.environment)}"
-  secret_value = module.ci_cd_sa.private_key_encoded
+  secret_name  = "GCLOUD_AUTH${local.secret_suffix}"
+  secret_value = try(lookup(module.ci_cd_sa.private_key_encoded, "ci-cd-pipeline", ""), "")
 }

--- a/modules/project/provider.tf
+++ b/modules/project/provider.tf
@@ -4,15 +4,15 @@ terraform {
 }
 
 provider "google" {
-  version     = "~> 2.7"
+  version     = "~> 3.8"
   region      = "europe-west-1"
   credentials = var.credentials
 }
 
-# provider "google-beta" {
-#   region      = "europe-west-1"
-#   credentials = var.credentials
-# }
+provider "google-beta" {
+  region      = "europe-west-1"
+  credentials = var.credentials
+}
 
 provider "gsuite" {
   impersonated_user_email = coalesce(var.impersonated_user_email, format("%s@%s", "terraform", var.domain))

--- a/modules/project/provider.tf
+++ b/modules/project/provider.tf
@@ -9,6 +9,11 @@ provider "google" {
   credentials = var.credentials
 }
 
+# provider "google-beta" {
+#   region      = "europe-west-1"
+#   credentials = var.credentials
+# }
+
 provider "gsuite" {
   impersonated_user_email = coalesce(var.impersonated_user_email, format("%s@%s", "terraform", var.domain))
 

--- a/modules/project/vars.tf
+++ b/modules/project/vars.tf
@@ -155,12 +155,14 @@ variable secret_manager_sa {
 
 variable services {
   type = list(object({
-    name      = string
-    iam_roles = list(string)
+    name       = string
+    repository = string
+    iam_roles  = list(string)
   }))
   default = [
     {
-      name = "foo"
+      name       = "foo"
+      repository = "foo"
       iam_roles = [
         "bar"
       ]


### PR DESCRIPTION
* Set the `GCLOUD_AUTH_*` secret in GitHub service repos
* Upgrade to v8.0.0 of google-project-factory to be able to use google provider 3.8+ which includes secret manager in the google-beta provider

The `github-secret` factory depends on a `github-token` secret loaded from our `tf-admin` project's Secret Manager. The token is used to set the secrets in GitHub.