### PR TITLE
ELY-277 Make `terraform plan` fully determined

### DIFF
--- a/modules/external-project-iam-roles/README.md
+++ b/modules/external-project-iam-roles/README.md
@@ -18,6 +18,7 @@
 | parent\_project\_iam\_roles | List of IAM Roles to add to the parent project | `list(string)` | n/a | yes |
 | parent\_project\_id | ID of the project to which add additional IAM roles for current project's CI/CD service account. Don't add roles if value is empty | `string` | n/a | yes |
 | service\_account | Service account email to add IAM roles in parent project for | `string` | n/a | yes |
+| service\_account\_exists | If service_account for service exists or not | `bool` | n/a | yes |
 
 ## Outputs
 

--- a/modules/external-project-iam-roles/main.tf
+++ b/modules/external-project-iam-roles/main.tf
@@ -1,5 +1,5 @@
 resource "google_project_iam_member" "parent_project_roles" {
-  for_each = (var.parent_project_id != "") && (var.service_account != "") ? toset(var.parent_project_iam_roles) : toset([])
+  for_each = (var.parent_project_id != "") && (var.service_account_exists) ? toset(var.parent_project_iam_roles) : toset([])
 
   project = var.parent_project_id
   role    = each.key
@@ -7,7 +7,7 @@ resource "google_project_iam_member" "parent_project_roles" {
 }
 
 resource "google_project_iam_member" "gcr_project_roles" {
-  for_each = (var.gcr_project_id != "") && (var.service_account != "") ? toset(var.gcr_project_iam_roles) : toset([])
+  for_each = (var.gcr_project_id != "") && (var.service_account_exists) ? toset(var.gcr_project_iam_roles) : toset([])
 
   project = var.gcr_project_id
   role    = each.key
@@ -31,7 +31,7 @@ resource "google_project_iam_member" "gke_gcr_roles" {
 }
 
 resource "google_project_iam_member" "dns_project_roles" {
-  for_each = var.dns_project_id != "" && (var.service_account != "") ? toset(var.dns_project_iam_roles) : toset([])
+  for_each = var.dns_project_id != "" && (var.service_account_exists) ? toset(var.dns_project_iam_roles) : toset([])
 
   project = var.dns_project_id
   role    = each.key

--- a/modules/external-project-iam-roles/vars.tf
+++ b/modules/external-project-iam-roles/vars.tf
@@ -47,3 +47,8 @@ variable gke_gcr_iam_roles {
   type        = list(string)
   description = "List of IAM Roles to add to the GCR project"
 }
+
+variable service_account_exists {
+  type        = bool
+  description = "If service_account for service exists or not"
+}

--- a/modules/github-secret/README.md
+++ b/modules/github-secret/README.md
@@ -14,6 +14,7 @@
 | repositories | The GitHub repositories to update | `list(string)` | n/a | yes |
 | secret\_name | The GitHub secret name | `string` | n/a | yes |
 | secret\_value | The plaintext secret value to be encrypted with GitHub | `string` | `""` | no |
+| create\_secret | If actually create a secret | `bool` | true | no |
 
 ## Outputs
 

--- a/modules/github-secret/main.tf
+++ b/modules/github-secret/main.tf
@@ -12,13 +12,13 @@ provider "github" {
 }
 
 data "github_actions_public_key" "repo_key" {
-  for_each = var.secret_value != "" ? toset(var.repositories) : toset([])
+  for_each = var.create_secret ? toset(var.repositories) : toset([])
 
   repository = each.key
 }
 
 resource "github_actions_secret" "gcloud_secret" {
-  for_each = var.secret_value != "" ? toset(var.repositories) : toset([])
+  for_each = var.create_secret ? toset(var.repositories) : toset([])
 
   repository      = each.key
   secret_name     = var.secret_name

--- a/modules/github-secret/vars.tf
+++ b/modules/github-secret/vars.tf
@@ -25,3 +25,9 @@ variable secret_value {
   type        = string
   default     = ""
 }
+
+variable create_secret {
+  description = "If actually create a secret"
+  type        = bool
+  default     = true
+}

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -86,6 +86,7 @@ module "services_sa" {
 module "parent_project_iam" {
   source = "../external-project-iam-roles"
 
+  service_account_exists   = var.create_service_sa
   service_account          = local.ci_cd_sa_email
   parent_project_id        = var.parent_project_id
   parent_project_iam_roles = var.parent_project_iam_roles
@@ -111,8 +112,9 @@ module "workload-identity" {
 module "github_secret" {
   source = "../github-secret"
 
-  repositories = var.services[*].repository
+  repositories  = var.services[*].repository
 
-  secret_name  = "GCLOUD_AUTH${local.secret_suffix}"
-  secret_value = try(lookup(module.ci_cd_sa.private_key_encoded, "ci-cd-pipeline", ""), "")
+  create_secret = var.create_service_sa
+  secret_name   = "GCLOUD_AUTH${local.secret_suffix}"
+  secret_value  = try(lookup(module.ci_cd_sa.private_key_encoded, "ci-cd-pipeline", ""), "")
 }


### PR DESCRIPTION
Conditioned `for_each` was made for avoid created list of resources (for every service, etc)
if not planned to create related resources (service-account).
But module output or dynamic datasource was used to provide conditioned variable.
This make terraform fail since number of resources could not be determined on first run or `terraform plan`
This commt fixed it