### PR TITLE
add additional_user_access to prod env

### DIFF
--- a/modules/additional-user-access/README.md
+++ b/modules/additional-user-access/README.md
@@ -1,0 +1,19 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| additional\_user\_access | List of IAM Roles to assign to groups and users | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>    members = list(string)<br>  }))<br></pre> | n/a | yes |
+| clan\_gsuite\_group | The name of the clan gsuite group | `string` | n/a | yes |
+| domain | Domain name of the Organization | `string` | n/a | yes |
+| project\_id | Project ID to add IAM roles to | `string` | n/a | yes |
+
+
+## Outputs
+
+No output.

--- a/modules/additional-user-access/main.tf
+++ b/modules/additional-user-access/main.tf
@@ -1,0 +1,51 @@
+locals {
+  group_roles = flatten([for group_key, group in var.additional_user_access : [
+    for role_key, role in group.iam_roles : {
+      name = group.name
+      role = role
+    }
+    ]
+  ])
+  group_members = flatten([for group_key, group in var.additional_user_access : [
+    for member_key, member in group.members : {
+      name   = group.name
+      member = member
+    }
+  ]
+  ])
+}
+
+resource "gsuite_group" "access_group" {
+  for_each = {
+    for group in var.additional_user_access :
+    group.name => group
+  }
+  email       = "${var.clan_gsuite_group}-prod-${each.key}@${var.domain}"
+  name        = "${var.clan_gsuite_group}-prod-${each.key}"
+  description = "${each.key} GSuite Group"
+}
+
+
+resource "gsuite_group_member" "access_group_member" {
+  for_each = {
+    for group in local.group_members :
+    "${group.name}/${group.member}" => group
+  }
+  group = "${var.clan_gsuite_group}-prod-${each.value.name}@${var.domain}"
+  email = each.value.member
+  role  = "MEMBER"
+
+  depends_on = [gsuite_group.access_group]
+}
+
+resource "google_project_iam_member" "local_access_group_roles" {
+  for_each = {
+    for group in local.group_roles :
+    "${group.name}.${group.role}" => group
+  }
+  project = var.project_id
+  role    = each.value.role
+  member  = "group:${var.clan_gsuite_group}-prod-${each.value.name}@${var.domain}"
+
+  depends_on = [gsuite_group.access_group]
+}

--- a/modules/additional-user-access/vars.tf
+++ b/modules/additional-user-access/vars.tf
@@ -1,0 +1,22 @@
+variable project_id {
+  description = "Project ID to add IAM roles to"
+}
+
+variable additional_user_access {
+  type = list(object({
+    name      = string
+    iam_roles = list(string)
+    members   = list(string)
+  }))
+  description = "List of IAM Roles to assign to groups and users"
+}
+
+variable clan_gsuite_group {
+  type        = string
+  description = "The name of the clan gsuite group"
+}
+
+variable domain {
+  type        = string
+  description = "Domain name of the Organization - needed for var impersonated_user_email"
+}

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -125,3 +125,12 @@ module "github_secret" {
   secret_name   = "GCLOUD_AUTH${local.secret_suffix}"
   secret_value  = try(lookup(module.ci_cd_sa.private_key_encoded, "ci-cd-pipeline", ""), "")
 }
+
+module "additional_user_access" {
+  source = "../additional-user-access"
+
+  project_id             = module.project_factory.project_id
+  domain                 = var.domain
+  additional_user_access = var.additional_user_access
+  clan_gsuite_group      = var.clan_gsuite_group
+}

--- a/modules/project/vars.tf
+++ b/modules/project/vars.tf
@@ -288,3 +288,13 @@ variable gke_gcr_iam_roles {
     "roles/storage.objectViewer"
   ]
 }
+
+variable additional_user_access {
+  type = list(object({
+    name      = string
+    iam_roles = list(string)
+    members   = list(string)
+  }))
+  default = []
+  description = "List of IAM Roles to assign to groups and users"
+}


### PR DESCRIPTION
example of project.yaml: (users and groups have been combined in members)
```
...
additional_user_access:
  - name: secret-admin
    members:
        - name@extendaretail.com
    iam_roles:
      - roles/secretManager.admin
  - name: support
    members:
      - support-team@extendaretail.com
    iam_roles:
      - roles/viewer
```