### PR TITLE
Ely 294/fix gke resources

### DIFF
--- a/modules/additional-user-access/README.md
+++ b/modules/additional-user-access/README.md
@@ -13,7 +13,6 @@
 | domain | Domain name of the Organization | `string` | n/a | yes |
 | project\_id | Project ID to add IAM roles to | `string` | n/a | yes |
 
-
 ## Outputs
 
 No output.

--- a/modules/external-project-iam-roles/README.md
+++ b/modules/external-project-iam-roles/README.md
@@ -8,24 +8,19 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| common\_iam\_roles | List of IAM Roles to assign to every Services Service Account in Tribe project | `list(string)` | `[]` | no |
 | dns\_project\_iam\_roles | List of IAM Roles to add to DNS project | `list(string)` | n/a | yes |
 | dns\_project\_id | ID of the project hosting Google Cloud DNS | `string` | n/a | yes |
 | gcr\_project\_iam\_roles | List of IAM Roles to add GCR project | `list(string)` | n/a | yes |
 | gcr\_project\_id | ID of the project hosting Google Container Registry | `string` | n/a | yes |
-| gke\_gcr\_iam\_roles | List of IAM Roles to add to the GCR project | `list(string)` | n/a | yes |
-| gke\_parent\_iam\_roles | List of IAM Roles to add to the parent project | `list(string)` | n/a | yes |
-| gke\_service\_account | GKE service account email that IAM roles will be added to | `string` | n/a | yes |
 | parent\_project\_iam\_roles | List of IAM Roles to add to the parent project | `list(string)` | n/a | yes |
 | parent\_project\_id | ID of the project to which add additional IAM roles for current project's CI/CD service account. Don't add roles if value is empty | `string` | n/a | yes |
 | service\_account | Service account email to add IAM roles in parent project for | `string` | n/a | yes |
 | service\_account\_exists | If service_account for service exists or not | `bool` | n/a | yes |
 | project\_id | Local (clan) Project ID where service account is created | `string` | n/a | yes |
 | services | List of services with IAM roles | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))<br></pre> | n/a | yes |
-| common\_iam\_roles | List of IAM Roles to assign to every Services Service Account in Tribe project | `list(string)` | `[]` | no |
 | sa\_depends\_on | Service Account which this module depends on | `any` | n/a | yes |
-
 
 ## Outputs
 
 No output.
-

--- a/modules/external-project-iam-roles/main.tf
+++ b/modules/external-project-iam-roles/main.tf
@@ -37,22 +37,6 @@ resource "google_project_iam_member" "gcr_project_roles" {
   member  = "serviceAccount:${var.service_account}"
 }
 
-resource "google_project_iam_member" "gke_parent_roles" {
-  for_each = (var.parent_project_id != "") && (var.gke_service_account != "") ? toset(var.gke_parent_iam_roles) : toset([])
-
-  project = var.parent_project_id
-  role    = each.key
-  member  = "serviceAccount:${var.gke_service_account}"
-}
-
-resource "google_project_iam_member" "gke_gcr_roles" {
-  for_each = (var.parent_project_id != "") && (var.gke_service_account != "") ? toset(var.gke_gcr_iam_roles) : toset([])
-
-  project = var.gcr_project_id
-  role    = each.key
-  member  = "serviceAccount:${var.gke_service_account}"
-}
-
 resource "google_project_iam_member" "dns_project_roles" {
   for_each = var.dns_project_id != "" && (var.service_account_exists) ? toset(var.dns_project_iam_roles) : toset([])
 

--- a/modules/external-project-iam-roles/vars.tf
+++ b/modules/external-project-iam-roles/vars.tf
@@ -56,21 +56,6 @@ variable gcr_project_iam_roles {
   description = "List of IAM Roles to add GCR project"
 }
 
-variable gke_service_account {
-  type        = string
-  description = "GKE service account email that IAM roles will be added to"
-}
-
-variable gke_parent_iam_roles {
-  type        = list(string)
-  description = "List of IAM Roles to add to the parent project"
-}
-
-variable gke_gcr_iam_roles {
-  type        = list(string)
-  description = "List of IAM Roles to add to the GCR project"
-}
-
 variable service_account_exists {
   type        = bool
   description = "If service_account for service exists or not"

--- a/modules/github-secret/README.md
+++ b/modules/github-secret/README.md
@@ -19,4 +19,3 @@
 ## Outputs
 
 No output.
-

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -29,9 +29,6 @@ No provider.
 | folder\_id | The ID of a folder to host this project | `any` | n/a | yes |
 | gcr\_project\_iam\_roles | List of IAM Roles to add GCR project | `list(string)` | <pre>[<br>  "roles/storage.admin"<br>]</pre> | no |
 | gcr\_project\_id | ID of the project hosting Google Container Registry | `string` | `""` | no |
-| gke\_gcr\_iam\_roles | List of IAM Roles to add to the GCR project for GKE service account | `list(string)` | <pre>[<br>  "roles/storage.objectViewer"<br>]</pre> | no |
-| gke\_parent\_iam\_roles | List of IAM Roles to add to the parent project for GKE service account | `list(string)` | <pre>[<br>  "roles/logging.logWriter",<br>  "roles/monitoring.metricWriter",<br>  "roles/monitoring.viewer"<br>]</pre> | no |
-| gke\_service\_account | GKE service account email that IAM roles will be added to in the parent project | `string` | `""` | no |
 | impersonated\_user\_email | Email account of GSuite Admin user to impersonate for creating GSuite Groups. If not provided, will default to `terraform@<var.domain>` | `string` | `""` | no |
 | labels | Map of labels for the project | `map(string)` | `{}` | no |
 | name | The name for the project | `any` | n/a | yes |
@@ -39,9 +36,9 @@ No provider.
 | parent\_project\_iam\_roles | List of IAM Roles to add to the parent project | `list(string)` | <pre>[<br>  "roles/container.admin",<br>  "roles/iam.serviceAccountUser"<br>]</pre> | no |
 | parent\_project\_id | ID of the project to which add additional IAM roles for current project's CI/CD service account. Ignore if empty | `string` | `""` | no |
 | random\_project\_id | Adds a suffix of 4 random characters to the project\_id | `bool` | `true` | no |
-| secret\_manager\_sa | Map of IAM Roles to assign to the Secret Manager Access Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/secretmanager.secretAccessor"<br>    ],<br>    "name": "secret-accessor"<br>  }<br>]</pre> | no |
+| secret\_manager\_sa | Map of IAM Roles to assign to the Secret Manager Access Service Account |  <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre>  | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/secretmanager.secretAccessor"<br>    ],<br>    "name": "secret-accessor"<br>  }<br>]</pre> | no |
 | service\_group\_name | The name of the group that will be created for a service | `string` | `""` | no |
-| services | Map of IAM Roles to assign to the Services Service Account | <pre>list(object({<br>    name       = string<br>    repository = string<br>    iam_roles  = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "bar"<br>    ],<br>    "name": "foo",<br>    "repository": "foo"<br>  }<br>]</pre> | no |
+| services | Map of IAM Roles to assign to the Services Service Account |  <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre>  | [] | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |
 
@@ -52,11 +49,10 @@ No provider.
 | ci\_cd\_service\_account\_email | The CI/CD pipeline service account email |
 | ci\_cd\_service\_account\_private\_key\_encoded | The CI/CD pipeline service account base64 encoded JSON key |
 | cloudrun\_service\_account\_email | The Cloud Run service account email |
-| gsuite\_group\_email | n/a |
+| gsuite\_group\_email | The GSuite group emails created per each service |
 | project\_id | The project ID |
 | project\_name | The project name |
 | secret\_manager\_service\_account\_private\_key\_encoded | The Cloud Run service account base64 encoded JSON key |
 | service\_account\_email | The default service acccount email |
 | service\_emails | Services service account emails |
 | terraform\_state\_bucket | Bucket for saving terraform state of project resources |
-

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -93,18 +93,15 @@ module "parent_project_iam" {
   parent_project_id        = var.parent_project_id
   parent_project_iam_roles = var.parent_project_iam_roles
 
-  project_id        = module.project_factory.project_id
-  services          = var.services
-  common_iam_roles  = var.common_iam_roles
-  sa_depends_on     = module.services_sa.email
+  project_id       = module.project_factory.project_id
+  services         = var.services
+  common_iam_roles = var.common_iam_roles
+  sa_depends_on    = module.services_sa.email
 
   dns_project_id        = var.dns_project_id
   dns_project_iam_roles = var.dns_project_iam_roles
   gcr_project_id        = var.gcr_project_id
   gcr_project_iam_roles = var.gcr_project_iam_roles
-  gke_service_account   = var.gke_service_account
-  gke_parent_iam_roles  = var.gke_parent_iam_roles
-  gke_gcr_iam_roles     = var.gke_gcr_iam_roles
 }
 
 module "workload-identity" {

--- a/modules/project/outputs.tf
+++ b/modules/project/outputs.tf
@@ -52,5 +52,6 @@ output service_private_keys_encoded {
 }
 
 output gsuite_group_email {
-  value = module.services_sa.gsuite_group_email
+  description = "The GSuite group emails created per each service"
+  value       = module.services_sa.gsuite_group_email
 }

--- a/modules/project/vars.tf
+++ b/modules/project/vars.tf
@@ -47,7 +47,7 @@ variable default_service_account {
   default     = "deprivilege"
 }
 
-variable "labels" {
+variable labels {
   description = "Map of labels for the project"
   type        = map(string)
   default     = {}
@@ -158,14 +158,7 @@ variable services {
     name       = string
     iam_roles  = list(string)
   }))
-  default = [
-    {
-      name       = "foo"
-      iam_roles = [
-        "bar"
-      ]
-    }
-  ]
+  default = []
   description = "Map of IAM Roles to assign to the Services Service Account"
 }
 
@@ -262,30 +255,6 @@ variable gcr_project_iam_roles {
   description = "List of IAM Roles to add GCR project"
   default = [
     "roles/storage.admin"
-  ]
-}
-
-variable gke_service_account {
-  type        = string
-  description = "GKE service account email that IAM roles will be added to in the parent project"
-  default     = ""
-}
-
-variable gke_parent_iam_roles {
-  type        = list(string)
-  description = "List of IAM Roles to add to the parent project for GKE service account"
-  default = [
-    "roles/logging.logWriter",
-    "roles/monitoring.metricWriter",
-    "roles/monitoring.viewer"
-  ]
-}
-
-variable gke_gcr_iam_roles {
-  type        = list(string)
-  description = "List of IAM Roles to add to the GCR project for GKE service account"
-  default = [
-    "roles/storage.objectViewer"
   ]
 }
 


### PR DESCRIPTION
This PR removes not needed GKE resources that are handled by the GCP k8s module.
the only change we will need to do in the tribe terragrunt.hcl is `registry_project_id = "gcr-project-id"` 
These resources will be destroyed on the `clan project` level:
`gke_gcr_roles["roles/storage.objectViewer"] will be destroyed`
`gke_parent_roles["roles/logging.logWriter"] will be destroyed`
`gke_parent_roles["roles/monitoring.metricWriter"] will be destroyed`
`gke_parent_roles["roles/monitoring.viewer"] will be destroyed`

This resource will be modified on the `.../resources/env_name/gke` level:
`cluster_service_account-gcr[0] must be replaced` ("roles/storage.objectViewer" will be added to our gcr project)