### PR TITLE
feat: Add custom role for the Cloud Scheduler

### DIFF
--- a/modules/additional-user-access/main.tf
+++ b/modules/additional-user-access/main.tf
@@ -52,3 +52,18 @@ resource "google_project_iam_member" "local_access_group_roles" {
 
   depends_on = [gsuite_group.access_group]
 }
+
+resource "google_project_iam_custom_role" "cs_custom_role" {
+  role_id     = "cloudschedulerrole"
+  title       = "Cloud Scheduler role"
+  description = "The role for the Cloud Scheduler"
+  permissions = ["appengine.applications.create", "serviceusage.services.enable"]
+}
+
+resource "google_project_iam_member" "scheduler_role" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.cs_custom_role.name
+  member  = "${var.clan_gsuite_group}@${var.domain}"
+
+  depends_on = [google_project_iam_custom_role.cs_custom_role]
+}


### PR DESCRIPTION
```
  # module.additional_user_access.google_project_iam_custom_role.cs_custom_role will be created
  + resource "google_project_iam_custom_role" "cs_custom_role" {
      + deleted     = (known after apply)
      + description = "The role for the Cloud Scheduler"
      + id          = (known after apply)
      + name        = (known after apply)
      + permissions = [
          + "appengine.applications.create",
          + "serviceusage.services.enable",
        ]
      + project     = (known after apply)
      + role_id     = "cloudschedulerrole"
      + stage       = "GA"
      + title       = "Cloud Scheduler role"
    }

  # module.additional_user_access.google_project_iam_member.local_scheduler_role will be created
  + resource "google_project_iam_member" "local_scheduler_role" {
      + etag    = (known after apply)
      + id      = (known after apply)
      + member  = "group:tribe-experience-selfscan@extendaretail.com"
      + project = "selfscan-staging-2fd8"
      + role    = (known after apply)
    }
```