### PR TITLE
fix: Revert old submodule for external roles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,50 +86,23 @@ module "services_sa" {
   env_name   = var.env_name
 }
 
-module "services_parent_project_roles" {
-  source = "./modules/external-roles"
+module "parent_project_iam" {
+  source = "./modules/external-project-iam-roles"
 
-  roles_map = {
-    for service in var.services :
-    "${service.name}@${module.project_factory.project_id}.iam.gserviceaccount.com" => {
-      "${var.parent_project_id}" = var.common_iam_roles
-    }
+  service_account_exists   = var.create_service_sa
+  service_account          = local.ci_cd_sa_email
+  parent_project_id        = var.parent_project_id
+  parent_project_iam_roles = var.parent_project_iam_roles
 
-  }
-  sa_depends_on = module.services_sa.email
-}
+  project_id       = module.project_factory.project_id
+  services         = var.services
+  common_iam_roles = var.common_iam_roles
+  sa_depends_on    = module.services_sa.email
 
-module "parent_project_roles" {
-  source = "./modules/external-roles"
-
-  roles_map = {
-    "${local.ci_cd_sa_email}" = {
-      "${var.parent_project_id}" = var.parent_project_iam_roles
-    }
-  }
-  sa_depends_on = module.services_sa.email
-}
-
-module "dns_project_roles" {
-  source = "./modules/external-roles"
-
-  roles_map = {
-    "${local.ci_cd_sa_email}" = {
-      "${var.dns_project_id}" = var.dns_project_iam_roles
-    }
-  }
-  sa_depends_on = module.services_sa.email
-}
-
-module "gcr_project_roles" {
-  source = "./modules/external-roles"
-
-  roles_map = {
-    "${local.ci_cd_sa_email}" = {
-      "${var.gcr_project_id}" = var.gcr_project_iam_roles
-    }
-  }
-  sa_depends_on = module.services_sa.email
+  dns_project_id        = var.dns_project_id
+  dns_project_iam_roles = var.dns_project_iam_roles
+  gcr_project_id        = var.gcr_project_id
+  gcr_project_iam_roles = var.gcr_project_iam_roles
 }
 
 module "custom_external_roles" {

--- a/modules/external-project-iam-roles/README.md
+++ b/modules/external-project-iam-roles/README.md
@@ -1,0 +1,26 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| common\_iam\_roles | List of IAM Roles to assign to every Services Service Account in Tribe project | `list(string)` | `[]` | no |
+| dns\_project\_iam\_roles | List of IAM Roles to add to DNS project | `list(string)` | n/a | yes |
+| dns\_project\_id | ID of the project hosting Google Cloud DNS | `string` | n/a | yes |
+| gcr\_project\_iam\_roles | List of IAM Roles to add GCR project | `list(string)` | n/a | yes |
+| gcr\_project\_id | ID of the project hosting Google Container Registry | `string` | n/a | yes |
+| parent\_project\_iam\_roles | List of IAM Roles to add to the parent project | `list(string)` | n/a | yes |
+| parent\_project\_id | ID of the project to which add additional IAM roles for current project's CI/CD service account. Don't add roles if value is empty | `string` | n/a | yes |
+| service\_account | Service account email to add IAM roles in parent project for | `string` | n/a | yes |
+| service\_account\_exists | If service_account for service exists or not | `bool` | n/a | yes |
+| project\_id | Local (clan) Project ID where service account is created | `string` | n/a | yes |
+| services | List of services with IAM roles | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))<br></pre> | n/a | yes |
+| sa\_depends\_on | Service Account which this module depends on | `any` | n/a | yes |
+
+## Outputs
+
+No output.

--- a/modules/external-project-iam-roles/main.tf
+++ b/modules/external-project-iam-roles/main.tf
@@ -1,0 +1,46 @@
+locals {
+  service_roles = flatten([for service_key, service in var.services : [
+    for role_key, role in var.common_iam_roles : {
+      name = service.name
+      role = role
+    }
+    ]
+  ])
+}
+
+resource "google_project_iam_member" "parent_project_service_roles" {
+  for_each = {
+    for service in local.service_roles :
+    "${service.name}.${service.role}" => service
+    if var.service_account_exists == true
+  }
+  project = var.parent_project_id
+  role    = each.value.role
+  member  = "serviceAccount:${each.value.name}@${var.project_id}.iam.gserviceaccount.com"
+
+  depends_on = [var.sa_depends_on]
+}
+
+resource "google_project_iam_member" "parent_project_roles" {
+  for_each = (var.parent_project_id != "") && (var.service_account_exists) ? toset(var.parent_project_iam_roles) : toset([])
+
+  project = var.parent_project_id
+  role    = each.key
+  member  = "serviceAccount:${var.service_account}"
+}
+
+resource "google_project_iam_member" "gcr_project_roles" {
+  for_each = (var.gcr_project_id != "") && (var.service_account_exists) ? toset(var.gcr_project_iam_roles) : toset([])
+
+  project = var.gcr_project_id
+  role    = each.key
+  member  = "serviceAccount:${var.service_account}"
+}
+
+resource "google_project_iam_member" "dns_project_roles" {
+  for_each = var.dns_project_id != "" && (var.service_account_exists) ? toset(var.dns_project_iam_roles) : toset([])
+
+  project = var.dns_project_id
+  role    = each.key
+  member  = "serviceAccount:${var.service_account}"
+}

--- a/modules/external-project-iam-roles/vars.tf
+++ b/modules/external-project-iam-roles/vars.tf
@@ -1,0 +1,62 @@
+variable project_id {
+  description = "Local (clan) Project ID where service account is created"
+}
+
+variable services {
+  type = list(object({
+    name      = string
+    iam_roles = list(string)
+  }))
+  description = "List of services with IAM roles"
+}
+
+variable common_iam_roles {
+  description = "List of IAM Roles to assign to every Services Service Account in Tribe project"
+  type        = list(string)
+  default     = []
+}
+
+variable sa_depends_on {
+  description = "Service Account which this module depends on"
+  type        = any
+}
+
+variable parent_project_id {
+  type        = string
+  description = "ID of the project to which add additional IAM roles for current project's CI/CD service account. Don't add roles if value is empty"
+}
+
+variable service_account {
+  type        = string
+  description = "Service account email to add IAM roles in parent project for"
+}
+
+variable parent_project_iam_roles {
+  type        = list(string)
+  description = "List of IAM Roles to add to the parent project"
+}
+
+variable dns_project_id {
+  type        = string
+  description = "ID of the project hosting Google Cloud DNS"
+}
+
+variable dns_project_iam_roles {
+  type        = list(string)
+  description = "List of IAM Roles to add to DNS project"
+}
+
+variable gcr_project_id {
+  type        = string
+  description = "ID of the project hosting Google Container Registry"
+}
+
+variable gcr_project_iam_roles {
+  type        = list(string)
+  description = "List of IAM Roles to add GCR project"
+}
+
+variable service_account_exists {
+  type        = bool
+  description = "If service_account for service exists or not"
+}


### PR DESCRIPTION
I could not finally fix the issue 
```
Error: Invalid for_each argument

The "for_each" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
```
when passing `local.ci_cd_sa_email` to the refactored module, so this PR revert previously used  `external-project-iam-roles` submodule and keeps `external-roles` submodule for add specific roles.
The overcoming solution becomes too complex and hard to support.

The current rollback is temporary. After Terraform 0.13 will be released we'll refactor it again using new module-centric workflow features.