### PR TITLE
chore(ELY-456): Remove hard-coded project_id, secret and github organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ GSuite Provider must be manually downloaded and installed in `$HOME/.terraform.d
 | domain | Domain name of the Organization | `string` | n/a | yes |
 | env\_name | Environment name (staging/prod). Creation of some resources depends on env\_name | `string` | `""` | no |
 | folder\_id | The ID of a folder to host this project | `any` | n/a | yes |
+| github\_organization | GitHub organization to use GitHub prodifer with | `string` | `extenda` | no |
+| github\_token\_gcp\_project | GCP project that contains Secret Manager for Github token | `string` | `tf-admin-90301274` | no |
+| github\_token\_gcp\_secret | SGP secret name for GitHub token | `string` | `github-token` | no |
 | gcr\_project\_iam\_roles | List of IAM Roles to add GCR project | `list(string)` | <pre>[<br>  "roles/storage.admin"<br>]</pre> | no |
 | gcr\_project\_id | ID of the project hosting Google Container Registry | `string` | `""` | no |
 | impersonated\_user\_email | Email account of GSuite Admin user to impersonate for creating GSuite Groups. If not provided, will default to `terraform@<var.domain>` | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,10 @@ module "workload-identity" {
 module "github_secret" {
   source = "./modules/github-secret"
 
+  github_token_gcp_project = var.github_token_gcp_project
+  github_token_gcp_secret  = var.github_token_gcp_secret
+  github_organization      = var.github_organization
+
   repositories = var.repositories
 
   create_secret = var.create_service_sa

--- a/modules/github-secret/README.md
+++ b/modules/github-secret/README.md
@@ -9,7 +9,8 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
-| gcp\_secret\_project | GCP project that contains Secret Manager | `string` | `"pipeline-secrets-1136"` | no |
+| github\_token\_gcp\_project | GCP project that contains Secret Manager for Github token | `string` | n/a | yes |
+| github_token_gcp_secret | SGP secret name for GitHub token | `string` | n/a | yes |
 | github\_organization | GitHub organization | `string` | `"extenda"` | no |
 | repositories | The GitHub repositories to update | `list(string)` | n/a | yes |
 | secret\_name | The GitHub secret name | `string` | n/a | yes |

--- a/modules/github-secret/main.tf
+++ b/modules/github-secret/main.tf
@@ -1,8 +1,8 @@
 data "google_secret_manager_secret_version" "github_token" {
   provider = google-beta
 
-  project = var.gcp_secret_project
-  secret  = "github-token"
+  project = var.github_token_gcp_project
+  secret  = var.github_token_gcp_secret
 }
 
 provider "github" {

--- a/modules/github-secret/vars.tf
+++ b/modules/github-secret/vars.tf
@@ -1,13 +1,16 @@
-variable gcp_secret_project {
-  description = "GCP project that contains Secret Manager"
+variable github_token_gcp_project {
+  description = "GCP project that contains Secret Manager for Github token"
   type        = string
-  default     = "tf-admin-90301274"
+}
+
+variable github_token_gcp_secret {
+  description = "SGP secret name for GitHub token"
+  type        = string
 }
 
 variable github_organization {
   description = "GitHub organization"
   type        = string
-  default     = "extenda"
 }
 
 variable repositories {

--- a/vars.tf
+++ b/vars.tf
@@ -30,6 +30,24 @@ variable activate_apis {
   description = "The list of apis to activate within the project"
 }
 
+variable github_organization {
+  type        = string
+  description = "GitHub organization to use GitHub prodifer with"
+  default     = "extenda"
+}
+
+variable github_token_gcp_project {
+  type        = string
+  description = "GCP project that contains Secret Manager for Github token"
+  default     = "tf-admin-90301274"
+}
+
+variable github_token_gcp_secret {
+  type        = string
+  description = "SGP secret name for GitHub token"
+  default     = "github-token"
+}
+
 variable shared_vpc {
   type        = string
   description = "The ID of the host project which hosts the shared VPC"


### PR DESCRIPTION
This PR removes hard-coded values for secret manager project_id, secret name, and GitHub organization
for be able to test or run the module without access to `tf-admin-90301274` project.