### PR TITLE
feat: Ability to pass GitHub token value directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ GSuite Provider must be manually downloaded and installed in `$HOME/.terraform.d
 | github\_organization | GitHub organization to use GitHub prodifer with | `string` | `extenda` | no |
 | github\_token\_gcp\_project | GCP project that contains Secret Manager for Github token | `string` | `tf-admin-90301274` | no |
 | github\_token\_gcp\_secret | SGP secret name for GitHub token | `string` | `github-token` | no |
+| github\_token | GitHub token value (instead of query GCP secret) | `string` | `""` | no |
 | gcr\_project\_iam\_roles | List of IAM Roles to add GCR project | `list(string)` | <pre>[<br>  "roles/storage.admin"<br>]</pre> | no |
 | gcr\_project\_id | ID of the project hosting Google Container Registry | `string` | `""` | no |
 | impersonated\_user\_email | Email account of GSuite Admin user to impersonate for creating GSuite Groups. If not provided, will default to `terraform@<var.domain>` | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,7 @@ module "workload-identity" {
 module "github_secret" {
   source = "./modules/github-secret"
 
+  github_token             = var.github_token
   github_token_gcp_project = var.github_token_gcp_project
   github_token_gcp_secret  = var.github_token_gcp_secret
   github_organization      = var.github_organization

--- a/modules/github-secret/README.md
+++ b/modules/github-secret/README.md
@@ -11,6 +11,7 @@
 |------|-------------|------|---------|:-----:|
 | github\_token\_gcp\_project | GCP project that contains Secret Manager for Github token | `string` | n/a | yes |
 | github_token_gcp_secret | SGP secret name for GitHub token | `string` | n/a | yes |
+| github\_token | GitHub token value (instead of query GCP secret) | `string` | `""` | no |
 | github\_organization | GitHub organization | `string` | `"extenda"` | no |
 | repositories | The GitHub repositories to update | `list(string)` | n/a | yes |
 | secret\_name | The GitHub secret name | `string` | n/a | yes |

--- a/modules/github-secret/main.tf
+++ b/modules/github-secret/main.tf
@@ -1,13 +1,14 @@
 data "google_secret_manager_secret_version" "github_token" {
   provider = google-beta
 
+  count   = (var.github_token == "") ? 1 : 0
   project = var.github_token_gcp_project
   secret  = var.github_token_gcp_secret
 }
 
 provider "github" {
   version      = "~> 2.0"
-  token        = data.google_secret_manager_secret_version.github_token.secret_data
+  token        = (var.github_token != "") ? var.github_token : data.google_secret_manager_secret_version.github_token[0].secret_data
   organization = var.github_organization
 }
 

--- a/modules/github-secret/vars.tf
+++ b/modules/github-secret/vars.tf
@@ -8,6 +8,12 @@ variable github_token_gcp_secret {
   type        = string
 }
 
+variable github_token {
+  type        = string
+  description = "GitHub token value (instead of query GCP secret)"
+  default     = ""
+}
+
 variable github_organization {
   description = "GitHub organization"
   type        = string

--- a/vars.tf
+++ b/vars.tf
@@ -48,6 +48,12 @@ variable github_token_gcp_secret {
   default     = "github-token"
 }
 
+variable github_token {
+  type        = string
+  description = "GitHub token value (instead request GCP secret)"
+  default     = ""
+}
+
 variable shared_vpc {
   type        = string
   description = "The ID of the host project which hosts the shared VPC"


### PR DESCRIPTION
Although recently `github_token_gcp_project` and `github_token_gcp_secret` variables were added to remove hard-coding of secret handling  GitHub secret it still needs a way to save the token somewhere in the project.
For service account that has no access to any project except sandbox it's not applicable.
This PR adds the ability to specify Github token value directly to input variable.