### PR TITLE
feat: Add role to Pub-Sub service account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,6 +95,7 @@ module "parent_project_iam" {
   parent_project_iam_roles = var.parent_project_iam_roles
 
   project_id       = module.project_factory.project_id
+  project_number   = module.project_factory.project_number
   services         = var.services
   common_iam_roles = var.common_iam_roles
   sa_depends_on    = module.services_sa.email

--- a/modules/external-project-iam-roles/main.tf
+++ b/modules/external-project-iam-roles/main.tf
@@ -6,6 +6,7 @@ locals {
     }
     ]
   ])
+  pubsub_sa = "service-${var.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
 resource "google_project_iam_member" "parent_project_service_roles" {
@@ -43,4 +44,10 @@ resource "google_project_iam_member" "dns_project_roles" {
   project = var.dns_project_id
   role    = each.key
   member  = "serviceAccount:${var.service_account}"
+}
+
+resource "google_project_iam_member" "pubsub_sa_role" {
+  project = var.project_id
+  role    = "roles/iam.ServiceAccountTokenCreator"
+  member  = "serviceAccount:${local.pubsub_sa}"
 }

--- a/modules/external-project-iam-roles/vars.tf
+++ b/modules/external-project-iam-roles/vars.tf
@@ -2,6 +2,10 @@ variable project_id {
   description = "Local (clan) Project ID where service account is created"
 }
 
+variable project_number {
+  description = "Local (clan) Project Number where service account exists"
+}
+
 variable services {
   type = list(object({
     name      = string


### PR DESCRIPTION
Example
```
  # module.parent_project_iam.google_project_iam_member.pubsub_sa_role will be created
  + resource "google_project_iam_member" "pubsub_sa_role" {
      + etag    = (known after apply)
      + id      = (known after apply)
      + member  = "serviceAccount:service-648363493658@gcp-sa-pubsub.iam.gserviceaccount.com"
      + project = "quotes-staging-ccdf"
      + role    = "roles/iam.ServiceAccountTokenCreator"
    }
```