### PR TITLE
chore: Change gcp permissions to bucket-level instead of project-level

### DIFF
--- a/modules/external-project-iam-roles/main.tf
+++ b/modules/external-project-iam-roles/main.tf
@@ -29,12 +29,12 @@ resource "google_project_iam_member" "parent_project_roles" {
   member  = "serviceAccount:${var.service_account}"
 }
 
-resource "google_project_iam_member" "gcr_project_roles" {
+resource "google_storage_bucket_iam_member" "gcr_bucket_roles" {
   for_each = (var.gcr_project_id != "") && (var.service_account_exists) ? toset(var.gcr_project_iam_roles) : toset([])
 
-  project = var.gcr_project_id
-  role    = each.key
-  member  = "serviceAccount:${var.service_account}"
+  bucket = "eu.artifacts.${var.gcr_project_id}.appspot.com"
+  role   = "each.key"
+  member = "serviceAccount:${var.service_account}"
 }
 
 resource "google_project_iam_member" "dns_project_roles" {


### PR DESCRIPTION
This PR set permissions on to GCR on bucket-level instead of project-level for ci/cd SA as we have currently.
