### PR TITLE
feat(ELY-537): Update to project factory 9.1, compatiple with Terraform 0.13

### DIFF
--- a/MIGRATION_8.x-9.0.md
+++ b/MIGRATION_8.x-9.0.md
@@ -1,0 +1,33 @@
+
+`tf-module-gcp-project` v9.x is based on new major release of
+[terraform-google-project-factory](https://github.com/terraform-google-modules/terraform-google-project-factory/) 9.x,
+which has breaking changes but also compatible with Terraform 0.13
+
+## Update to tf-module-gcp-project v9.x 
+
+Next steps need to be applied to update to `tf-module-gcp-project` v9.x and Terraform 0.13.x:
+
+1. Staying with Terraform 0.12 update `tf-module-gcp-project`  to v9.0 for tribe and clan projects
+
+2. To not recreate shared vpc subnets in clan projects move terraform resources:
+``` bash
+terragrunt state mv module.project_factory.module.project-factory.google_compute_subnetwork_iam_member.gke_shared_vpc_subnets[0] \
+  module.project_factory.module.shared_vpc_access.google_compute_subnetwork_iam_member.service_shared_vpc_subnet_users[0]
+
+terragrunt state mv module.project_factory.module.project-factory.google_project_iam_member.gke_host_agent[0] \
+  module.project_factory.module.shared_vpc_access.google_project_iam_member.gke_host_agent[0]
+```
+
+3. Run `terragrunt apply` to apply the changes of brought from 
+
+4. Update to Terraform 0.13.4
+
+5. Replace gsuite provider in state files for every project `tf-module-gcp-project` and `terraform-google-project-factory` modules
+
+```bash
+terragrunt state replace-provider -auto-approve registry.terraform.io/-/gsuite registry.terraform.io/deviavir/gsuite
+```
+
+6. Run `terragrunt plan` and `terragrunt apply` again to confirm all state and changes are in sync.
+
+7. Profit

--- a/MIGRATION_8.x-9.0.md
+++ b/MIGRATION_8.x-9.0.md
@@ -7,7 +7,7 @@ which has breaking changes but also compatible with Terraform 0.13
 
 Next steps need to be applied to update to `tf-module-gcp-project` v9.x and Terraform 0.13.x:
 
-1. Staying with Terraform 0.12 update `tf-module-gcp-project`  to v9.0 for tribe and clan projects
+1. Using Terraform 0.12.x upgrade the `tf-module-gcp-project` to v9.0 for tribe and clan projects
 
 2. To not recreate shared vpc subnets in clan projects move terraform resources:
 ``` bash
@@ -18,7 +18,7 @@ terragrunt state mv module.project_factory.module.project-factory.google_project
   module.project_factory.module.shared_vpc_access.google_project_iam_member.gke_host_agent[0]
 ```
 
-3. Run `terragrunt apply` to apply the changes of brought from 
+3. Run `terragrunt apply` to apply the changes from new module version
 
 4. Update to Terraform 0.13.4
 
@@ -27,7 +27,6 @@ terragrunt state mv module.project_factory.module.project-factory.google_project
 ```bash
 terragrunt state replace-provider -auto-approve registry.terraform.io/-/gsuite registry.terraform.io/deviavir/gsuite
 ```
+6. Run `terragrunt init` to download new compatible providers for Terraform 0.13
 
-6. Run `terragrunt plan` and `terragrunt apply` again to confirm all state and changes are in sync.
-
-7. Profit
+7. Run `terragrunt plan` again to confirm all state and changes are in sync.

--- a/main.tf
+++ b/main.tf
@@ -4,8 +4,8 @@ locals {
 }
 
 module "project_factory" {
-  source  = "terraform-google-modules/project-factory/google"
-  version = "8.1"
+  source  = "terraform-google-modules/project-factory/google//modules/shared_vpc"
+  version = "9.1"
 
   name              = var.name
   random_project_id = var.random_project_id

--- a/modules/additional-user-access/providers.tf
+++ b/modules/additional-user-access/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    gsuite = {
+      source = "DeviaVir/gsuite"
+      version = "~> 0.1.35"
+    }
+  }
+}

--- a/modules/external-project-iam-roles/providers.tf
+++ b/modules/external-project-iam-roles/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/modules/external-roles/providers.tf
+++ b/modules/external-roles/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/modules/github-secret/providers.tf
+++ b/modules/github-secret/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    github = {
+      source = "hashicorp/github"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+  }
+}

--- a/modules/service-account/providers.tf
+++ b/modules/service-account/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/modules/services/providers.tf
+++ b/modules/services/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    gsuite = {
+      source = "DeviaVir/gsuite"
+      version = "~> 0.1.35"
+    }
+  }
+}

--- a/modules/workload-identity/providers.tf
+++ b/modules/workload-identity/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,10 +1,22 @@
 terraform {
   # The configuration for this backend will be filled in by Terragrunt
   required_version = ">= 0.12.18"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version     = "~> 3.8"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+    gsuite = {
+      source = "DeviaVir/gsuite"
+      version = "~> 0.1.35"
+    }
+  }
 }
 
 provider "google" {
-  version     = "~> 3.8"
   region      = "europe-west-1"
   credentials = var.credentials
 }
@@ -22,6 +34,4 @@ provider "gsuite" {
     "https://www.googleapis.com/auth/admin.directory.group",
     "https://www.googleapis.com/auth/admin.directory.group.member"
   ]
-
-  version = "~> 0.1.35"
 }


### PR DESCRIPTION
In terraform-google-project-factory 9.1 critical bugs for us was fixed. Also Terraform 0.13.4 is stable and have commands to automatic migrate. Both made success of migration to Terraform 0.13, which provides this PR.