### PR TITLE
feat: Add pact-broker secrets to clan projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,24 +18,27 @@ GSuite Provider must be manually downloaded and installed in `$HOME/.terraform.d
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | activate\_apis | The list of apis to activate within the project | `list(string)` | n/a | yes |
+| additional\_user\_access | List of IAM Roles to assign to groups and users | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>    members   = list(string)<br>  }))</pre> | `[]` | no |
 | billing\_account | The ID of the billing account to associate this project with | `any` | n/a | yes |
 | bucket\_name | The name of the bucket that will contain terraform state - must be globally unique | `any` | n/a | yes |
-| ci\_cd\_sa | Map of IAM Roles to assign to the CI/CD Pipeline Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/iam.serviceAccountUser",<br>      "roles/run.admin",<br>      "roles/storage.admin"<br>    ],<br>    "name": "ci-cd-pipeline"<br>  }<br>]</pre> | no |
+| ci\_cd\_sa | Map of IAM Roles to assign to the CI/CD Pipeline Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/cloudsql.editor",<br>      "roles/iam.serviceAccountUser",<br>      "roles/run.admin",<br>      "roles/storage.admin",<br>      "roles/cloudfunctions.admin",<br>      "roles/secretmanager.secretAccessor",<br>      "roles/dataflow.admin",<br>      "roles/bigquery.admin"<br>    ],<br>    "name": "ci-cd-pipeline"<br>  }<br>]</pre> | no |
 | clan\_gsuite\_group | The name of the clan group that needs to be added to the Service GSuite Group | `string` | `""` | no |
 | cloudrun\_sa | Map of IAM Roles to assign to the CloudRun Runtime Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/editor",<br>      "roles/secretmanager.secretAccessor"<br>    ],<br>    "name": "cloudrun-runtime"<br>  }<br>]</pre> | no |
+| common\_iam\_roles | Default list of IAM Roles to assign to every Services Service Account | `list(string)` | <pre>[<br>  "roles/monitoring.metricWriter",<br>  "roles/logging.logWriter",<br>  "roles/monitoring.viewer",<br>  "roles/cloudtrace.agent",<br>  "roles/secretmanager.secretAccessor"<br>]</pre> | no |
 | create\_ci\_cd\_group | If the Service GSuite Group should be created for the CI/CD Service Account | `bool` | `false` | no |
 | create\_ci\_cd\_service\_account | If the CI/CD Service Account should be created | `bool` | `true` | no |
 | create\_cloudrun\_group | If the Service GSuite Group should be created for the CloudRun Runtime Service Account | `bool` | `false` | no |
 | create\_cloudrun\_service\_account | If the CloudRun Runtime Service Account should be created | `bool` | `true` | no |
 | create\_custom\_roles | If the Custom Roles from the additioanl-use-access submodule should be created | `bool` | `true` | no |
+| create\_pact\_secrets | If the pact-broker secrets should be created | `bool` | `false` | no |
 | create\_sa | If the Service Account should be created | `bool` | `true` | no |
 | create\_secret\_manager\_group | If the Service GSuite Group should be created for the Secret Manager Access Service Account | `bool` | `false` | no |
 | create\_secret\_manager\_service\_account | If the Secret Manager Access Service Account should be created | `bool` | `false` | no |
 | create\_service\_sa | If the Service Account for new Services should be created | `bool` | `true` | no |
 | create\_services\_group | If the Service GSuite Group should be created for the Services (services variable) | `bool` | `true` | no |
-| credentials | JSON encoded service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fallback to GOOGLE\_APPLICATION\_CREDENTIALS env variable. | `any` | n/a | yes |
+| credentials | JSON encoded service account credentials file with rights to run the Project Factory. If this file is absent Terraform will fallback to GOOGLE\_APPLICATION\_CREDENTIALS env variable. | `any` | `null` | no |
 | custom\_external\_roles | Map of service or service account to external projects to list of iam roles for add | `map(map(list(string)))` | `{}` | no |
 | default\_service\_account | Project default service account setting: can be one of delete, deprivilege, disable, or keep. | `string` | `"deprivilege"` | no |
 | dns\_project\_iam\_roles | List of IAM Roles to add to DNS project | `list(string)` | <pre>[<br>  "roles/dns.admin"<br>]</pre> | no |
@@ -43,25 +46,31 @@ GSuite Provider must be manually downloaded and installed in `$HOME/.terraform.d
 | domain | Domain name of the Organization | `string` | n/a | yes |
 | env\_name | Environment name (staging/prod). Creation of some resources depends on env\_name | `string` | `""` | no |
 | folder\_id | The ID of a folder to host this project | `any` | n/a | yes |
-| github\_organization | GitHub organization to use GitHub prodifer with | `string` | `extenda` | no |
-| github\_token\_gcp\_project | GCP project that contains Secret Manager for Github token | `string` | `tf-admin-90301274` | no |
-| github\_token\_gcp\_secret | SGP secret name for GitHub token | `string` | `github-token` | no |
-| github\_token | GitHub token value (instead of query GCP secret) | `string` | `""` | no |
 | gcr\_project\_iam\_roles | List of IAM Roles to add GCR project | `list(string)` | <pre>[<br>  "roles/storage.admin"<br>]</pre> | no |
 | gcr\_project\_id | ID of the project hosting Google Container Registry | `string` | `""` | no |
+| github\_organization | GitHub organization to use GitHub prodifer with | `string` | `"extenda"` | no |
+| github\_token | GitHub token value (instead request GCP secret) | `string` | `""` | no |
+| github\_token\_gcp\_project | GCP project that contains Secret Manager for Github token | `string` | `"tf-admin-90301274"` | no |
+| github\_token\_gcp\_secret | SGP secret name for GitHub token | `string` | `"github-token"` | no |
+| gke\_ca\_certificate | Kubernetes certificate | `string` | `""` | no |
+| gke\_host | Kubernetes endpoint | `string` | `"no-gke-host"` | no |
 | impersonated\_user\_email | Email account of GSuite Admin user to impersonate for creating GSuite Groups. If not provided, will default to `terraform@<var.domain>` | `string` | `""` | no |
 | labels | Map of labels for the project | `map(string)` | `{}` | no |
 | name | The name for the project | `any` | n/a | yes |
 | org\_id | The organization ID | `any` | n/a | yes |
-| parent\_project\_iam\_roles | List of IAM Roles to add to the parent project | `list(string)` | <pre>[<br>  "roles/container.admin",<br>  "roles/iam.serviceAccountUser"<br>]</pre> | no |
+| pact\_project\_id | GCP project that contains secrets for pact-broker | `string` | `"platform-prod-2481"` | no |
+| pactbroker\_pass\_secret | GCP secret name for pact-broker password | `string` | `"pactbroker_password"` | no |
+| pactbroker\_user\_secret | GCP secret name for pact-broker user | `string` | `"pactbroker_username"` | no |
+| parent\_project\_iam\_roles | List of IAM Roles to add to the parent project | `list(string)` | <pre>[<br>  "roles/monitoring.admin",<br>  "roles/iam.serviceAccountUser"<br>]</pre> | no |
 | parent\_project\_id | ID of the project to which add additional IAM roles for current project's CI/CD service account. Ignore if empty | `string` | `""` | no |
+| project\_type | what type of project this is applied to | `string` | `"clan_project"` | no |
 | random\_project\_id | Adds a suffix of 4 random characters to the project\_id | `bool` | `true` | no |
-| secret\_manager\_sa | Map of IAM Roles to assign to the Secret Manager Access Service Account |  <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre>  | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/secretmanager.secretAccessor"<br>    ],<br>    "name": "secret-accessor"<br>  }<br>]</pre> | no |
+| repositories | The GitHub repositories to update | `list(string)` | `[]` | no |
+| secret\_manager\_sa | Map of IAM Roles to assign to the Secret Manager Access Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "iam_roles": [<br>      "roles/secretmanager.secretAccessor"<br>    ],<br>    "name": "secret-accessor"<br>  }<br>]</pre> | no |
+| service\_accounts | Map of IAM Roles to assign to the Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | `[]` | no |
 | service\_group\_name | The name of the group that will be created for a service | `string` | `""` | no |
-| service\_accounts | Map of IAM Roles to assign to the Service Account |  <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre>  | [] | no |
-| services | Map of IAM Roles to assign to the Services Service Account |  <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre>  | [] | no |
+| services | Map of IAM Roles to assign to the Services Service Account | <pre>list(object({<br>    name      = string<br>    iam_roles = list(string)<br>  }))</pre> | `[]` | no |
 | shared\_vpc | The ID of the host project which hosts the shared VPC | `string` | `""` | no |
-| project_type | project type this is applied to | `string` | `clan_project` | no |
 | shared\_vpc\_subnets | List of subnets fully qualified subnet IDs (ie. projects/$project\_id/regions/$region/subnetworks/$subnet\_id) | `list(string)` | `[]` | no |
 
 ## Outputs
@@ -71,12 +80,14 @@ GSuite Provider must be manually downloaded and installed in `$HOME/.terraform.d
 | ci\_cd\_service\_account\_email | The CI/CD pipeline service account email |
 | ci\_cd\_service\_account\_private\_key\_encoded | The CI/CD pipeline service account base64 encoded JSON key |
 | cloudrun\_service\_account\_email | The Cloud Run service account email |
+| enabled\_apis | Enabled APIs in the project |
 | gsuite\_group\_email | The GSuite group emails created per each service |
 | project\_id | The project ID |
 | project\_name | The project name |
+| project\_number | The project number |
 | secret\_manager\_service\_account\_private\_key\_encoded | The Cloud Run service account base64 encoded JSON key |
 | service\_account\_email | The default service acccount email |
-| service\_account\_emails | The service account emails created by service-account submodule |
 | service\_account\_private\_keys\_encoded | Service accounts base64 encoded JSON keys |
 | service\_emails | Services service account emails |
+| service\_private\_keys\_encoded | The Services service account base64 encoded JSON key |
 | terraform\_state\_bucket | Bucket for saving terraform state of project resources |

--- a/main.tf
+++ b/main.tf
@@ -178,3 +178,12 @@ module "gke_resources" {
   sa_depends_on      = module.services_sa.email
 }
 
+module "pact_broker" {
+  source = "./modules/pact-broker"
+
+  pact_project_id        = var.pact_project_id
+  project_id             = module.project_factory.project_id
+  pactbroker_user_secret = var.pactbroker_user_secret
+  pactbroker_pass_secret = var.pactbroker_pass_secret
+  create_pact_secrets    = var.create_pact_secrets
+}

--- a/modules/pact-broker/README.md
+++ b/modules/pact-broker/README.md
@@ -1,0 +1,21 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| create\_pact\_secrets | If the pact-broker secrets should be created | `bool` | n/a | yes |
+| pact\_project\_id | GCP project that contains secrets for pact-broker | `string` | n/a | yes |
+| pactbroker\_pass | Pact-broker password value (instead of query GCP secret) | `string` | `""` | no |
+| pactbroker\_pass\_secret | GCP secret name for pact-broker password | `string` | n/a | yes |
+| pactbroker\_user | Pact-broker user value (instead of query GCP secret) | `string` | `""` | no |
+| pactbroker\_user\_secret | GCP secret name for pact-broker user | `string` | n/a | yes |
+| project\_id | Project ID where secrets will be copied to | `string` | n/a | yes |
+
+## Outputs
+
+No output.

--- a/modules/pact-broker/main.tf
+++ b/modules/pact-broker/main.tf
@@ -1,0 +1,53 @@
+data "google_secret_manager_secret_version" "pactbroker_user" {
+  project = var.pact_project_id
+  secret  = var.pactbroker_user_secret
+}
+
+data "google_secret_manager_secret_version" "pactbroker_pass" {
+  project = var.pact_project_id
+  secret  = var.pactbroker_pass_secret
+}
+
+resource "google_secret_manager_secret" "user_secret_id" {
+  count     = var.create_pact_secrets ? 1 : 0
+
+  secret_id = data.google_secret_manager_secret_version.pactbroker_user.secret
+
+  labels = {
+    terraform = ""
+  }
+
+  replication {
+    automatic = true
+  }
+  project = var.project_id
+}
+
+resource "google_secret_manager_secret_version" "user_secret_value" {
+  count    = var.create_pact_secrets ? 1 : 0
+
+  secret      = google_secret_manager_secret.user_secret_id[0].id
+  secret_data = data.google_secret_manager_secret_version.pactbroker_user.secret_data
+}
+
+resource "google_secret_manager_secret" "pass_secret_id" {
+  count    = var.create_pact_secrets ? 1 : 0
+
+  secret_id = data.google_secret_manager_secret_version.pactbroker_pass.secret
+
+  labels = {
+    terraform = ""
+  }
+
+  replication {
+    automatic = true
+  }
+  project = var.project_id
+}
+
+resource "google_secret_manager_secret_version" "pass_secret_value" {
+  count    = var.create_pact_secrets ? 1 : 0
+
+  secret      = google_secret_manager_secret.pass_secret_id[0].id
+  secret_data = data.google_secret_manager_secret_version.pactbroker_pass.secret_data
+}

--- a/modules/pact-broker/providers.tf
+++ b/modules/pact-broker/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+  }
+}

--- a/modules/pact-broker/vars.tf
+++ b/modules/pact-broker/vars.tf
@@ -1,0 +1,36 @@
+variable project_id {
+  description = "Project ID where secrets will be copied to"
+  type        = string
+}
+
+variable pact_project_id {
+  description = "GCP project that contains secrets for pact-broker"
+  type        = string
+}
+
+variable pactbroker_user {
+  description = "Pact-broker user value (instead of query GCP secret)"
+  type        = string
+  default     = ""
+}
+
+variable pactbroker_user_secret {
+  description = "GCP secret name for pact-broker user"
+  type        = string
+}
+
+variable pactbroker_pass {
+  description = "Pact-broker password value (instead of query GCP secret)"
+  type        = string
+  default     = ""
+}
+
+variable pactbroker_pass_secret {
+  description = "GCP secret name for pact-broker password"
+  type        = string
+}
+
+variable create_pact_secrets {
+  description = "If the pact-broker secrets should be created"
+  type        = bool
+}

--- a/vars.tf
+++ b/vars.tf
@@ -343,3 +343,29 @@ variable project_type {
   type        = string
   default     = "clan_project"
 }
+
+# Pact-broker
+
+variable pactbroker_user_secret {
+  type        = string
+  description = "GCP secret name for pact-broker user"
+  default     = "pactbroker_username"
+}
+
+variable pactbroker_pass_secret {
+  type        = string
+  description = "GCP secret name for pact-broker password"
+  default     = "pactbroker_password"
+}
+
+variable create_pact_secrets {
+  description = "If the pact-broker secrets should be created"
+  type        = bool
+  default     = false
+}
+
+variable pact_project_id {
+  description = "GCP project that contains secrets for pact-broker"
+  type        = string
+  default     = "platform-prod-2481"
+}


### PR DESCRIPTION
This PR adds the ability to copy pact-broker secrets (needed for authorization) that are stored in the platform-prod project if the `create_pact_secrets = true`.