### PR TITLE
feat: Add Cloud Datastore Import Export Admin to be able to do backups

### DIFF
--- a/vars.tf
+++ b/vars.tf
@@ -119,6 +119,7 @@ variable ci_cd_sa {
         "roles/secretmanager.secretAccessor",
         "roles/dataflow.admin",
         "roles/bigquery.admin"
+        "roles/datastore.importExportAdmin"
       ]
     }
   ]


### PR DESCRIPTION
The role is needed in oeder to run backups.